### PR TITLE
Fix CloudflareClient::Zone::Firewall::WAFPackage::Rule#list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ branches:
 
 script: 
   - if [[ "$TASK" == "rspec" ]]; then bundle exec rspec; fi
-  - if [[ "$TASK" == "srcclr" ]]; then curl -sSL https://download.sourceclear.com/ci.sh | bash; fi
 
 env:
   - TASK=rspec
-  - TASK=srcclr

--- a/lib/cloudflare_client/zone/firewall/waf_package/rule.rb
+++ b/lib/cloudflare_client/zone/firewall/waf_package/rule.rb
@@ -24,7 +24,7 @@ class CloudflareClient::Zone::Firewall::WAFPackage::Rule < CloudflareClient::Zon
     params[:group_id] unless group_id.nil?
     params[:description] unless description.nil?
 
-    cf_get(path: "/zones/#{zone_id}/waf/packages/#{package_id}/rules", params: params)
+    cf_get(path: "/zones/#{zone_id}/firewall/waf/packages/#{package_id}/rules", params: params)
   end
 
   ##

--- a/spec/cloudflare_client/zone/firewall/waf_package/rule_spec.rb
+++ b/spec/cloudflare_client/zone/firewall/waf_package/rule_spec.rb
@@ -14,7 +14,7 @@ describe CloudflareClient::Zone::Firewall::WAFPackage::Rule do
 
   describe '#list' do
     before do
-      stub_request(:get, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/waf/packages/#{package_id}/rules?direction=desc&match=all&order=priority&page=1&per_page=50").
+      stub_request(:get, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/firewall/waf/packages/#{package_id}/rules?direction=desc&match=all&order=priority&page=1&per_page=50").
         to_return(response_body(waf_packages_rule_list))
     end
 


### PR DESCRIPTION
This endpoint was wrong:

Currently it raises:

```ruby
pry(#<CloudflareClient::Zone::Firewall::WAFPackage::Rule>):1> list
CloudflareClient::BadRequest: 400 Bad Request
from /usr/local/bundle/gems/cloudflare_client_rb-4.2.0/lib/cloudflare_client/middleware/response/raise_error.rb:68:in `handle_status'
pry(#<CloudflareClient::Zone::Firewall::WAFPackage::Rule>):1> puts _ex_.response.body
{"success":false,"errors":[{"code":7003,"message":"Could not route to \/zones\/xxx\/waf\/packages\/xxx\/rules, perhaps your object identifier is invalid?"},{"code":7000,"message":"No route for that URI"}],"messages":[],"result":null}
=> nil
```

Correct URL is in: https://api.cloudflare.com/#waf-rules-list-rules

Confirmed this worked in manual test too.

cc @zendesk/stanchion