### PR TITLE
Dont leak credentials in error message

### DIFF
--- a/lib/cloudflare_client/middleware/response/raise_error.rb
+++ b/lib/cloudflare_client/middleware/response/raise_error.rb
@@ -4,7 +4,7 @@ class CloudflareClient
     attr_reader :response, :method, :uri, :url
 
     def initialize(message = nil, response = nil, method = nil, uri = nil, url = nil)
-      super("#{message}, #{method.upcase} #{url} #{response.inspect}")
+      super("#{message}, #{method.upcase} #{url} #{response.body}")
       @response = response
       @method = method
       @uri = uri


### PR DESCRIPTION
Error messages now look like:
`CloudflareClient::BadRequest: 400 Bad Request, GET https://api.cloudflare.com/client/v4/zones/<some_zone_id>/custom_hostnames?direction=desc&hostname=lah&order=ssl&page=1&per_page=50&ssl=0 {"success":false,"errors":[{"code":10000,"message":"Authentication error"}]}`

cc @zendesk/stanchion 