### PR TITLE
Fix regression introduced when improving error messaging

### DIFF
--- a/lib/cloudflare_client/middleware/response/raise_error.rb
+++ b/lib/cloudflare_client/middleware/response/raise_error.rb
@@ -4,7 +4,7 @@ class CloudflareClient
     attr_reader :response, :method, :uri, :url
 
     def initialize(message = nil, response = nil, method = nil, uri = nil, url = nil)
-      super("#{message}, #{method.upcase} #{url} #{response.body}")
+      super("#{message}, #{method&.upcase} #{url} #{response&.body}")
       @response = response
       @method = method
       @uri = uri

--- a/spec/lib/cloudflare_client/middleware/response/raise_error_spec.rb
+++ b/spec/lib/cloudflare_client/middleware/response/raise_error_spec.rb
@@ -172,6 +172,14 @@ describe CloudflareClient::Middleware::Response::RaiseError do
     end
   end
 
+  describe "ResponseError" do
+    context "#initialize" do
+      it 'can be instantiated with nil params' do
+        CloudflareClient::ResponseError.new
+      end
+    end
+  end
+
   def response_status(status)
     service.get('/foo') { status }
     connection.get('/foo')


### PR DESCRIPTION
Nils should be allowed when instantiating ResponseError objects

cc @zendesk/stanchion 