### PR TITLE
[EDGE-4804] Fixes typo on one of the Custom SSL endpoint URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Basic examples:
 
 ```ruby
 # List zones - https://api.cloudflare.com/#zone-list-zones
-zone_client = CloudflareClient::Zone.new(auth_key: auth_key, email: email, zone_id: zone_id)
+zone_client = CloudflareClient::Zone.new(auth_key: auth_key, email: email)
 pp zone_client.zones
 
 # Example result:

--- a/lib/cloudflare_client/zone/custom_ssl.rb
+++ b/lib/cloudflare_client/zone/custom_ssl.rb
@@ -26,7 +26,7 @@ class CloudflareClient::Zone::CustomSSL < CloudflareClient::Zone::Base
     params = {page: page, per_page: per_page}
     params[:match] = match
     params[:direction] = direction
-    cf_get(path: "/zones/#{zone_id}/custom_certficates", params: params)
+    cf_get(path: "/zones/#{zone_id}/custom_certificates", params: params)
   end
 
   ##

--- a/spec/cloudflare_client/zone/custom_ssl_spec.rb
+++ b/spec/cloudflare_client/zone/custom_ssl_spec.rb
@@ -44,7 +44,7 @@ describe CloudflareClient::Zone::CustomSSL do
 
   describe '#list' do
     before do
-      stub_request(:get, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/custom_certficates?direction=asc&match=all&page=1&per_page=50").
+      stub_request(:get, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/custom_certificates?direction=asc&match=all&page=1&per_page=50").
         to_return(response_body(custom_ssl_list))
     end
 


### PR DESCRIPTION
* Makes the README reflect the current state of the API of this library.
* Fixes a typo on the endpoint URL for custom_certificates.