### PR TITLE
Adds support for Cloudflare Workers KV + Custom Hostnames v2

### DIFF
--- a/lib/cloudflare_client.rb
+++ b/lib/cloudflare_client.rb
@@ -180,10 +180,13 @@ class CloudflareClient
     JSON.parse(result.body, symbolize_names: true)
   end
 
-  def cf_put(path: nil, data: nil)
+  def cf_put(path: nil, data: nil, params: nil)
     result = @cf_client.put do |request|
       request.url(API_BASE + path) unless path.nil?
       request.body = data.to_json unless data.nil?
+      unless params.nil?
+        request.params = params if params.values.any? { |i| !i.nil? }
+      end
     end
     JSON.parse(result.body, symbolize_names: true)
   end

--- a/lib/cloudflare_client/namespace.rb
+++ b/lib/cloudflare_client/namespace.rb
@@ -1,0 +1,12 @@
+class CloudflareClient::Namespace < CloudflareClient
+  Dir[File.expand_path('../namespace/*.rb', __FILE__)].each {|f| require f}
+
+  attr_reader :account_id
+
+  def initialize(args)
+    @account_id = args.delete(:account_id)
+    id_check(:account_id, account_id)
+    super
+  end
+
+end

--- a/lib/cloudflare_client/namespace/value.rb
+++ b/lib/cloudflare_client/namespace/value.rb
@@ -16,6 +16,10 @@ class CloudflareClient::Value < CloudflareClient::Namespace
     cf_put(path: "/accounts/#{account_id}/storage/kv/namespaces/#{namespace_id}/values/#{key}", data: data, params: {expiration_ttl: expiration_ttl})
   end
 
+  def read(key:)
+    cf_get(path: "/accounts/#{account_id}/storage/kv/namespaces/#{namespace_id}/values/#{key}", raw: true)
+  end
+
   def delete(key:)
     cf_delete(path: "/accounts/#{account_id}/storage/kv/namespaces/#{namespace_id}/values/#{key}")
   end

--- a/lib/cloudflare_client/namespace/value.rb
+++ b/lib/cloudflare_client/namespace/value.rb
@@ -1,0 +1,19 @@
+class CloudflareClient::Value < CloudflareClient::Namespace
+  attr_reader :namespace_id
+
+  def initialize(args)
+    @namespace_id = args.delete(:namespace_id)
+    id_check(:namespace_id, namespace_id)
+    super
+  end
+
+  def write(key:, value:, expiration_ttl: nil, metadata: nil)
+    if expiration_ttl
+      raise RuntimeError, 'expiration_ttl must be an integer' unless expiration_ttl.kind_of?(Integer)
+    end
+
+    data = metadata ? { value: value, metadata: metadata} : value
+    cf_put(path: "/accounts/#{account_id}/storage/kv/namespaces/#{namespace_id}/values/#{key}", data: data, params: {expiration_ttl: expiration_ttl})
+  end
+
+end

--- a/lib/cloudflare_client/namespace/value.rb
+++ b/lib/cloudflare_client/namespace/value.rb
@@ -16,4 +16,7 @@ class CloudflareClient::Value < CloudflareClient::Namespace
     cf_put(path: "/accounts/#{account_id}/storage/kv/namespaces/#{namespace_id}/values/#{key}", data: data, params: {expiration_ttl: expiration_ttl})
   end
 
+  def delete(key:)
+    cf_delete(path: "/accounts/#{account_id}/storage/kv/namespaces/#{namespace_id}/values/#{key}")
+  end
 end

--- a/lib/cloudflare_client/zone/custom_hostname_v2.rb
+++ b/lib/cloudflare_client/zone/custom_hostname_v2.rb
@@ -1,0 +1,24 @@
+require_relative 'custom_hostname'
+#class CloudflareClient::Zone::CustomHostnameV2 < CloudflareClient::Zone::Base
+class CloudflareClient::Zone::CustomHostnameV2 < CloudflareClient::Zone::CustomHostname
+
+  def create(hostname:, ssl: DEFAULT_SSL_PROPERTIES, custom_metadata: {}, custom_origin_server: nil)
+    super
+  end
+
+  def list(hostname: nil, id: nil, page: 1, per_page: 50, order: 'ssl', direction: 'desc', ssl: 0)
+    super
+  end
+
+  def show(id:)
+    super
+  end
+
+  def update(id:, ssl: {}, custom_metadata: nil, custom_origin_server: nil)
+    super
+  end
+
+  def delete(id:)
+    super
+  end
+end

--- a/lib/cloudflare_client/zone/custom_hostname_v2.rb
+++ b/lib/cloudflare_client/zone/custom_hostname_v2.rb
@@ -1,5 +1,5 @@
 require_relative 'custom_hostname'
-#class CloudflareClient::Zone::CustomHostnameV2 < CloudflareClient::Zone::Base
+# https://api.cloudflare.com/#custom-hostname-for-a-zone-list-custom-hostnames
 class CloudflareClient::Zone::CustomHostnameV2 < CloudflareClient::Zone::CustomHostname
 
   def create(hostname:, ssl: DEFAULT_SSL_PROPERTIES, custom_metadata: {}, custom_origin_server: nil)

--- a/spec/cloudflare_client/namespace/value_spec.rb
+++ b/spec/cloudflare_client/namespace/value_spec.rb
@@ -49,6 +49,23 @@ describe CloudflareClient::Namespace::Value do
     end
   end
 
+  describe '#read' do
+    before do
+      stub_request(:get, "https://api.cloudflare.com/client/v4/accounts/#{account_id}/storage/kv/namespaces/#{namespace_id}/values/#{key}").
+        to_return(response_body(value_read))
+    end
+
+    let(:value_read) { Faker::Alphanumeric.alpha(number: 10) }
+
+    it 'returns the value associated with the given key in the given namespace' do
+      expect(client.read(key: key)).to eq(value_read)
+    end
+
+    it 'fails to return the value associated with the given key in the given namespace' do
+      expect { client.read }. to raise_error(ArgumentError, 'missing keyword: key')
+    end
+  end
+
   describe '#delete' do
     before do
       stub_request(:delete, "https://api.cloudflare.com/client/v4/accounts/#{account_id}/storage/kv/namespaces/#{namespace_id}/values/#{key}").

--- a/spec/cloudflare_client/namespace/value_spec.rb
+++ b/spec/cloudflare_client/namespace/value_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+SingleCov.covered!
+
+describe CloudflareClient::Namespace::Value do
+  subject(:client) { described_class.new(account_id: account_id, namespace_id: namespace_id, auth_key: 'somefakekey', email: 'foo@bar.com') }
+
+  let(:account_id) { 'abc1234' }
+  let(:namespace_id) { 'def5678' }
+  let(:key) { 'My-Key' }
+  let(:value1) { 'Some Value' }
+  let(:value2) { 'Another Value' }
+  let(:value3) { 'More Value' }
+  let(:expiration_ttl) { 500 }
+  let(:metadata) { '{"someMetadataKey": "someMetadataValue"}' }
+
+  describe '#write' do
+    before do
+      stub_request(:put, "https://api.cloudflare.com/client/v4/accounts/#{account_id}/storage/kv/namespaces/#{namespace_id}/values/#{key}").
+        with(body: "\"Some Value\"").
+        to_return(response_body(value_write))
+      stub_request(:put, "https://api.cloudflare.com/client/v4/accounts/#{account_id}/storage/kv/namespaces/#{namespace_id}/values/#{key}?expiration_ttl=#{expiration_ttl}").
+        with(body: "\"Another Value\"", query: {expiration_ttl: 500}).
+        to_return(response_body(value_write))
+      stub_request(:put, "https://api.cloudflare.com/client/v4/accounts/#{account_id}/storage/kv/namespaces/#{namespace_id}/values/#{key}").
+        with(body: "{\"value\":\"More Value\",\"metadata\":\"{\\\"someMetadataKey\\\": \\\"someMetadataValue\\\"}\"}").
+        to_return(response_body(value_write))
+    end
+
+    let(:value_write) { create(:value_write) }
+    
+    it 'writes a value identified by a key' do
+      expect(client.write(key: key, value: value1)).to eq(value_write)
+    end
+
+    it 'writes a value identified by a key with expiration TTL' do
+      expect(client.write(key: key, value: value2, expiration_ttl: 500)).to eq(value_write)
+    end
+
+    it 'writes a value identiifed by a key with metadata' do
+      expect(client.write(key: key, value: value3, metadata: metadata)).to eq(value_write)
+    end
+
+    it 'fails to write a value identified by a key' do
+      expect { client.write(key: 'key') }.to raise_error(ArgumentError, 'missing keyword: value')
+      expect { client.write(value: 'value') }.to raise_error(ArgumentError, 'missing keyword: key')
+
+      expect { client.write(key: 'key', value: 'value', expiration_ttl: '500') }.to raise_error(RuntimeError, "expiration_ttl must be an integer")
+    end
+  end
+
+end
+

--- a/spec/cloudflare_client/namespace/value_spec.rb
+++ b/spec/cloudflare_client/namespace/value_spec.rb
@@ -49,5 +49,21 @@ describe CloudflareClient::Namespace::Value do
     end
   end
 
+  describe '#delete' do
+    before do
+      stub_request(:delete, "https://api.cloudflare.com/client/v4/accounts/#{account_id}/storage/kv/namespaces/#{namespace_id}/values/#{key}").
+        to_return(response_body(value_delete))
+    end
+
+    let(:value_delete) { create(:value_write) }
+
+    it 'removes a KV pair from the Namespace' do
+      expect(client.delete(key: key)).to eq(value_delete)
+    end
+
+    it 'fails to delete a KV pair from the namesapce' do
+      expect { client.delete }.to raise_error(ArgumentError, 'missing keyword: key')
+    end
+  end
 end
 

--- a/spec/cloudflare_client/zone/custom_hostname_v2_spec.rb
+++ b/spec/cloudflare_client/zone/custom_hostname_v2_spec.rb
@@ -1,0 +1,165 @@
+require 'spec_helper'
+
+SingleCov.covered!
+
+describe CloudflareClient::Zone::CustomHostnameV2 do
+  subject(:client) { described_class.new(zone_id: zone_id, auth_key: 'somefakekey', email: 'foo@bar.com') }
+
+  let(:zone_id) { 'abc1234' }
+
+  it_behaves_like 'initialize for zone features'
+
+  describe '#create' do
+    before do
+      stub_request(:post, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/custom_hostnames").
+        to_return(response_body(custom_hostname_v2_show))
+    end
+
+    let(:custom_hostname_v2_show) { create(:custom_hostname_v2_show) }
+
+    it 'creates a custom hostname' do
+      result = client.create(hostname: 'somerandomhost')
+      expect(result).to eq(custom_hostname_v2_show)
+    end
+
+    it 'fails to create a custom_hostname' do
+      expect { client.create }.to raise_error(ArgumentError, 'missing keyword: hostname')
+      expect { client.create(hostname: nil) }.to raise_error(RuntimeError, 'hostname required')
+
+      expect do
+        client.create(hostname: 'footothebar', ssl: { type: 'dv', method: 'snail' })
+      end.to raise_error(RuntimeError, "method must be one of #{described_class::VALID_METHODS}")
+
+      expect do
+        client.create(hostname: 'footothebar', ssl: { type: 'snail', method: 'http' })
+      end.to raise_error(RuntimeError, "type must be one of #{described_class::VALID_TYPES}")
+    end
+  end
+
+  describe '#list' do
+    before do
+      stub_request(:get, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/custom_hostnames?direction=desc&order=ssl&page=1&per_page=50&ssl=0").
+        to_return(response_body(custom_hostname_v2_list1))
+      stub_request(:get, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/custom_hostnames?direction=desc&id=#{id}&order=ssl&page=1&per_page=50&ssl=0").
+        to_return(response_body(custom_hostname_v2_list2))
+      stub_request(:get, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/custom_hostnames?direction=desc&hostname=#{hostname}&order=ssl&page=1&per_page=50&ssl=0").
+        to_return(response_body(custom_hostname_v2_list3))
+    end
+
+    let(:custom_hostname_v2_list1) { create(:custom_hostname_v2_list) }
+    let(:custom_hostname_v2_list2) { create(:custom_hostname_v2_list) }
+    let(:custom_hostname_v2_list3) { create(:custom_hostname_v2_list) }
+    let(:id) { '12345' }
+    let(:hostname) { 'foobar' }
+
+    it 'lists custom_hostnames' do
+      expect(client.list).to eq(custom_hostname_v2_list1)
+      expect(client.list(id: id)).to eq(custom_hostname_v2_list2)
+      expect(client.list(hostname: hostname)).to eq(custom_hostname_v2_list3)
+    end
+
+    it 'fails to list custom hostnames' do
+      expect { client.list(hostname: hostname, id: id) }.to raise_error(RuntimeError, 'cannot use both hostname and id')
+
+      expect do
+        client.list(order: 'invalid')
+      end.to raise_error(RuntimeError, "order must be one of #{described_class::VALID_ORDERS}")
+
+      expect do
+        client.list(direction: 'invalid')
+      end.to raise_error(RuntimeError, "direction must be one of #{described_class::VALID_DIRECTIONS}")
+
+      expect do
+        client.list(ssl: 'invalid')
+      end.to raise_error(RuntimeError, "ssl must be one of #{[0, 1]}")
+    end
+  end
+
+  describe '#show' do
+    before do
+      stub_request(:get, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/custom_hostnames/#{id}").
+        to_return(response_body(custom_hostname_v2_show))
+    end
+
+    let(:custom_hostname_v2_show) { create(:custom_hostname_v2_show) }
+    let(:id) { '12345' }
+
+    it 'returns details for a custom hostname' do
+      expect(client.show(id: id)).to eq(custom_hostname_v2_show)
+    end
+
+    it 'fails to get details for a custom hostname' do
+      expect { client.show }.to raise_error(ArgumentError, 'missing keyword: id')
+      expect { client.show(id: nil) }.to raise_error(RuntimeError, 'id required')
+    end
+  end
+
+  describe '#update' do
+    before do
+      stub_request(:patch, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/custom_hostnames/#{id}").
+        with(body: {ssl: {method: method, type: type}}).
+        to_return(response_body(custom_hostname_v2_update1))
+      stub_request(:patch, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/custom_hostnames/#{id}").
+        with(body: {ssl: {method: method, type: type}, custom_origin_server: custom_origin_server}).
+        to_return(response_body(custom_hostname_v2_update2))
+      stub_request(:patch, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/custom_hostnames/#{id}").
+        with(body: {ssl: {method: method, type: type}, custom_origin_server: custom_origin_server, custom_metadata: {foo: 'bar'}}).
+        to_return(response_body(custom_hostname_v2_update3))
+    end
+
+    let(:custom_hostname_v2_update1) { create(:custom_hostname_v2_update) }
+    let(:custom_hostname_v2_update2) { create(:custom_hostname_v2_update) }
+    let(:custom_hostname_v2_update3) { create(:custom_hostname_v2_update_with_metadata) }
+    let(:id) { 'foo' }
+    let(:method) { 'http' }
+    let(:type) { 'dv' }
+    let(:custom_origin_server) { 'footothebar' }
+
+    it 'updates a custom hostname' do
+      result = client.update(id: id, ssl: { method: method, type: type })
+      expect(result).to eq(custom_hostname_v2_update1)
+
+      result = client.update(id: id, ssl: { method: method, type: type }, custom_origin_server: custom_origin_server)
+      expect(result).to eq(custom_hostname_v2_update2)
+
+      result = client.update(id: id, ssl: { method: method, type: type }, custom_origin_server: custom_origin_server, custom_metadata: {foo: 'bar'})
+      expect(result).to eq(custom_hostname_v2_update3)
+    end
+
+    it 'fails to update a custom_hostname' do
+      expect { client.update }.to raise_error(ArgumentError, 'missing keyword: id')
+      expect { client.update(id: nil, ssl: { method: method, type: type }) }.to raise_error(RuntimeError, 'id required')
+
+      expect do
+        client.update(id: id, ssl: { method: 'invalid_method', type: type })
+      end.to raise_error(RuntimeError, "method must be one of #{described_class::VALID_METHODS}")
+
+      expect do
+        client.update(id: id, ssl: { method: method, type: 'invalid type' })
+      end.to raise_error(RuntimeError, "type must be one of #{described_class::VALID_TYPES}")
+
+      expect do
+        client.update(id: id, ssl: { method: method, type: type }, custom_metadata: 'bob')
+      end.to raise_error(RuntimeError, 'custom_metadata must be an object')
+    end
+  end
+
+  describe '#delete' do
+    before do
+      stub_request(:delete, "https://api.cloudflare.com/client/v4/zones/#{zone_id}/custom_hostnames/#{id}").
+        to_return(response_body(custom_hostname_delete))
+    end
+
+    let(:custom_hostname_delete) { create(:custom_hostname_delete) }
+    let(:id) { 'foo' }
+
+    it 'deletes a custom_hostname' do
+      expect(client.delete(id: id)).to eq(custom_hostname_delete)
+    end
+
+    it 'fails to delete a custom_hostname' do
+      expect { client.delete }.to raise_error(ArgumentError, 'missing keyword: id')
+      expect { client.delete(id: nil) }.to raise_error(RuntimeError, 'id required')
+    end
+  end
+end

--- a/spec/factories/namespaces/values.rb
+++ b/spec/factories/namespaces/values.rb
@@ -9,8 +9,6 @@ FactoryBot.define do
             messages { [] }
         end
 
-        factory :value_read { Faker::Alphanumeric.alpha(number: 10) }
-
         factory :value_delete do
             success { true }
             errors { [] }

--- a/spec/factories/namespaces/values.rb
+++ b/spec/factories/namespaces/values.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+    factory :values, class: Hash do
+        skip_create
+        initialize_with(&FactoryHelper.initializer)
+
+        factory :value_write do
+            success { true }
+            errors { [] }
+            messages { [] }
+        end
+
+        factory :value_read { Faker::Alphanumeric.alpha(number: 10) }
+
+        factory :value_delete do
+            success { true }
+            errors { [] }
+            messages { [] }
+        end
+    end    
+end

--- a/spec/factories/zones/custom_hostnames_v2.rb
+++ b/spec/factories/zones/custom_hostnames_v2.rb
@@ -1,0 +1,109 @@
+FactoryBot.define do
+  factory :custom_hostnames_v2, class: Hash do
+    skip_create
+    initialize_with(&FactoryHelper.initializer)
+
+    factory :custom_hostname_v2_list do
+      transient { result_count { rand(1..3) } }
+      success { true }
+      errors { [] }
+      messages { [] }
+      result { create_list(:custom_hostname_v2_result, result_count) }
+      result_info do
+        {
+          page:        1,
+          per_page:    20,
+          count:       result_count,
+          total_count: result_count
+        }
+      end
+    end
+
+    factory :custom_hostname_v2_result do
+      id { SecureRandom.uuid }
+      hostname { Faker::Internet.domain_name }
+      ssl do
+        {
+          status: 'pending_validation',
+          method: 'http',
+          type: 'dv',
+          cname_target: Faker::Internet.domain_name,
+          cname: "#{SecureRandom.uuid.gsub('-', '')}.#{Faker::Internet.domain_name}"
+        }
+      end
+    end
+
+    factory :custom_hostname_v2_result_with_metadata do
+      id { SecureRandom.uuid }
+      hostname { Faker::Internet.domain_name }
+      custom_metadata { { foo: 'bar' } }
+      ssl do
+        {
+          status: 'pending_validation',
+          method: 'http',
+          type: 'dv',
+          cname_target: Faker::Internet.domain_name,
+          cname: "#{SecureRandom.uuid.gsub('-', '')}.#{Faker::Internet.domain_name}"
+        }
+      end
+    end
+
+    factory :custom_hostname_v2_show do
+      success { true }
+      errors { [] }
+      messages { [] }
+      result { create(:custom_hostname_result) }
+      ownership_verification_http do 
+        { 
+          http_url: Faker::Internet.domain_name,
+          http_body: SecureRandom.uuid
+        }
+      end
+    end
+
+    factory :custom_hostname_v2_show_with_metadata do
+      success { true }
+      errors { [] }
+      messages { [] }
+      result { create(:custom_hostname_result_with_metadata) }
+      ownership_verification_http do 
+        { 
+          http_url: Faker::Internet.domain_name,
+          http_body: SecureRandom.uuid
+        }
+      end
+    end
+
+
+    factory :custom_hostname_v2_update do
+      success { true }
+      errors { [] }
+      messages { [] }
+      result { create(:custom_hostname_result) }
+      status { 'pending' }
+      ownership_verification_http do 
+        { 
+          http_url: Faker::Internet.domain_name,
+          http_body: SecureRandom.uuid
+        }
+      end
+    end
+
+    factory :custom_hostname_v2_update_with_metadata do
+      success { true }
+      errors { [] }
+      messages { [] }
+      result { create(:custom_hostname_result_with_metadata) }
+      ownership_verification_http do 
+        { 
+          http_url: Faker::Internet.domain_name,
+          http_body: SecureRandom.uuid
+        }
+      end
+    end
+
+    factory :custom_hostname_v2_delete do
+      id { SecureRandom.uuid }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@ Dir[File.expand_path('../support/*.rb', __FILE__)].each{ |f| require f }
 require 'cloudflare_client'
 
 RSpec.configure do |config|
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+  
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
The following resources will be used by stanchion in order to implement the flow for custom hostnames v2.

## Custom Hostname V2:
[Link](https://api.cloudflare.com/#custom-hostname-for-a-zone-list-custom-hostnames)
Endpoints are the same as "v1". Additional properties were added to the response.

```
{
  "success": true,
  "errors": [],
  "messages": [],
  "result": [
    {
...
    "status": "pending",
      "verification_errors": [
        "None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."
      ],
      "ownership_verification": {
        "type": "txt",
        "name": "_cf-custom-hostname.app.example.com",
        "value": "5cc07c04-ea62-4a5a-95f0-419334a875a4"
      },
      "ownership_verification_http": {
        "http_url": "http://custom.test.com/.well-known/cf-custom-hostname-challenge/0d89c70d-ad9f-4843-b99f-6cc0252067e9",
        "http_body": "5cc07c04-ea62-4a5a-95f0-419334a875a4"
      },
...
}
```

## Workers KV:
* [Read KV](https://api.cloudflare.com/#workers-kv-namespace-read-key-value-pair)
* [Write KV](https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair)
* [Write KV with Metadata](https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair-with-metadata)
* [Delete KV](https://api.cloudflare.com/#workers-kv-namespace-delete-key-value-pair)